### PR TITLE
[kube-prometheus-stack] Fix KubeClientCertificateExpiration false positives with cloud providers

### DIFF
--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-apiserver.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-apiserver.yaml
@@ -37,7 +37,7 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubeclientcertificateexpiration
         summary: Client certificate is about to expire.
       expr: |-
-        histogram_quantile(0.01, sum without (namespace, service, endpoint) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 604800
+        histogram_quantile(0.01, sum without (namespace, service, endpoint) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 601200
         and
         on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}job, cluster, instance) apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0
       for: {{ dig "KubeClientCertificateExpiration" "for" "5m" .Values.customRules }}


### PR DESCRIPTION
Fixes #6160

## What this PR does / why we need it
Prevents false positives in KubeClientCertificateExpiration alert when using cloud providers that renew certificates exactly 7 days before expiration.

## Problem
Cloud providers like DigitalOcean automatically renew certificates 7 days before expiration, causing the alert to trigger during normal maintenance operations.

## Solution
Change warning threshold from 7 days (604,800s) to 6 days 22 hours (601,200s) to create a 2-hour buffer.

## Changes
- Single line change: `604800` → `601200` in alert rule
- Prevents false positives during cloud provider maintenance
- Maintains security monitoring for real certificate issues
- Critical alert (<24h) remains unchanged for emergencies

## Testing
- Mathematically ensures cloud provider maintenance won't trigger warnings
- Still provides 6+ days warning for real certificate issues
- Backward compatible - no breaking changes
